### PR TITLE
moving error mass to ppm in USI

### DIFF
--- a/public/lorikeet/html/pride.html
+++ b/public/lorikeet/html/pride.html
@@ -89,6 +89,10 @@ function showData(){
         "showY":[1,1,0],
         "showZ":[0,0,0],
         "labelImmoniumIons": false,
+        "fragmentMassType": "mono",
+        "precursorMassType": "mono",
+        "massError": 20,
+        "massErrorUnit": "ppm",
         "labelReporters": false});
 }
 


### PR DESCRIPTION
This PR modified the spectrum viewer and defines as mz unit as ppm and default value: 20 ppm. 